### PR TITLE
depreciate the use of env var names with dots

### DIFF
--- a/cmd/chirpstack-geolocation-server/cmd/root.go
+++ b/cmd/chirpstack-geolocation-server/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -81,6 +82,18 @@ func initConfig() {
 		}
 	}
 
+	for _, pair := range os.Environ() {
+		d := strings.SplitN(pair, "=", 2)
+		if strings.Contains(d[0], ".") {
+			log.Warning("Using dots in env variable is illegal and deprecated. Please use double underscore `__` for: ", d[0])
+			underscoreName := strings.ReplaceAll(d[0], ".", "__")
+			// Set only when the underscore version doesn't already exist.
+			if _, exists := os.LookupEnv(underscoreName); !exists {
+				os.Setenv(underscoreName, d[1])
+			}
+		}
+	}
+
 	viperBindEnvs(config.C)
 
 	if err := viper.Unmarshal(&config.C); err != nil {
@@ -106,8 +119,11 @@ func viperBindEnvs(iface interface{}, parts ...string) {
 		case reflect.Struct:
 			viperBindEnvs(v.Interface(), append(parts, tv)...)
 		default:
-			key := strings.Join(append(parts, tv), ".")
-			viper.BindEnv(key)
+			// Bash doesn't allow env variable names with a dot so
+			// bind the double underscore version.
+			keyDot := strings.Join(append(parts, tv), ".")
+			keyUnderscore := strings.Join(append(parts, tv), "__")
+			viper.BindEnv(keyDot, strings.ToUpper(keyUnderscore))
 		}
 	}
 }


### PR DESCRIPTION
show a warning when using var names with dots and replace those with the
underscore versions.
The config are now bind to the underscore env name versions.

Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>